### PR TITLE
docs: add branch naming convention guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,40 @@ Guidance for agents working in `/home/danimatuko/dotfiles`.
 
 - Single file: `bash -n path/to/script`
 - Batch: `for f in setup/*.sh bin/*; do [ -f "$f" ] && bash -n "$f"; done`
+
+## Branch Naming Convention
+
+Use branch names in one of these formats:
+
+- Preferred: `<type>/<area>-<short-description>`
+- Allowed: `<type>/<short-description>`
+
+### Types
+
+- Required `type` values: `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, `test`, `perf`, `ci`, `revert`
+
+### Area and Description
+
+- `area` is optional but recommended (for example: `ags`, `hypr`, `setup`, `bin`, `nvim`)
+- `short-description` is required, action-focused, and lowercase kebab-case
+
+### Reserved Prefixes
+
+- `release/<date-or-version>` (for example: `release/2026-05-17`, `release/v1.2.0`)
+- `hotfix/<area>-<short-description>` (for example: `hotfix/hypr-lockscreen-crash`)
+
+### Examples
+
+- `feat/ags-quick-settings-grouping`
+- `fix/hyprlock-theme-paths`
+- `chore/setup-prune-legacy-links`
+- `docs/branch-naming-convention`
+- `refactor/bin-network-script-cleanup`
+- `fix/update-readme-links`
+
+### Rules
+
+- Use lowercase letters, numbers, and `-` only
+- Do not use spaces, underscores, or camelCase
+- Keep names concise (prefer ~50 characters or fewer)
+- Keep one primary concern per branch

--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ The desktop shell is based on AGS and runs on Hyprland.
 - Root repository behavior is script-driven; there is no root package.json task runner.
 - The only Node/TypeScript project in this repo is config/ags/.
 
+## Branch Naming
+
+Use branch names in one of these formats:
+
+- Preferred: `<type>/<area>-<short-description>`
+- Allowed: `<type>/<short-description>`
+
+Allowed `type` values:
+
+- `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, `test`, `perf`, `ci`, `revert`
+
+Reserved prefixes:
+
+- `release/<date-or-version>`
+- `hotfix/<area>-<short-description>`
+
+Examples:
+
+- `feat/ags-quick-settings-grouping`
+- `fix/hyprlock-theme-paths`
+- `chore/setup-prune-legacy-links`
+
+See `AGENTS.md` for full rules and additional examples.
+
 ## License
 
 MIT

--- a/config/ags/AGENTS.md
+++ b/config/ags/AGENTS.md
@@ -202,6 +202,13 @@ Use this profile when making AGS UI/UX changes unless the user explicitly asks o
 - Preferred types include `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, and `test`.
 - Do not use scope format like `type(scope):message` unless explicitly requested.
 
+## Branch Naming Convention
+
+- Branch naming follows the root convention in `AGENTS.md`.
+- Preferred format: `<type>/<area>-<short-description>`.
+- Allowed format: `<type>/<short-description>`.
+- AGS examples: `feat/ags-quick-settings-grouping`, `fix/ags-battery-indicator-click-action`.
+
 ## Cursor and Copilot Rules
 
 Checked for agent-policy files and none were found:


### PR DESCRIPTION
## Summary
- define a repo-wide branch naming convention in `AGENTS.md` with preferred/allowed patterns and examples
- document reserved prefixes for release and hotfix branches and add concise naming rules
- add branch naming references in `README.md` and `config/ags/AGENTS.md` to keep contributor guidance consistent