### PR TITLE
feat:refine wallpaper dock menu

### DIFF
--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -20,133 +20,95 @@ window.WallpaperMenu {
 
 .wallpaper-menu__panel {
   margin-top: 0;
-  padding: 18px;
-  min-width: 760px;
-  border-radius: $radius-lg;
-  border: 1px solid color-mix(in srgb, #{$color-brand} 24%, #{$bg-surface} 76%);
-  background:
-    radial-gradient(
-      140% 120% at 100% 0%,
-      rgba(255, 255, 255, 0.07) 0%,
-      transparent 60%
-    ),
-    linear-gradient(
-      160deg,
-      color-mix(in srgb, #{$bg-base} 92%, #{$bg-surface} 8%) 0%,
-      color-mix(in srgb, #{$bg-base} 82%, #{$bg-surface} 18%) 100%
-    );
-  box-shadow: 0 26px 56px rgba(0, 0, 0, 0.34);
-}
-
-.wallpaper-menu__header {
-  margin-bottom: 2px;
-  min-height: 34px;
-  align-items: center;
-}
-
-.wallpaper-menu__title {
-  font-size: 1.2rem;
-  font-weight: 700;
-  color: $color-emphasis;
-}
-
-.wallpaper-menu__count {
-  color: $color-muted;
-  font-size: 0.92rem;
-  min-width: 170px;
-}
-
-.wallpaper-menu__meta {
-  margin-bottom: 2px;
-}
-
-.wallpaper-menu__hint {
-  color: color-mix(in srgb, #{$color-muted} 88%, #{$color-on-surface} 12%);
-  font-size: 0.82rem;
-}
-
-.wallpaper-menu__toggle-label {
-  color: $color-on-surface;
-  font-size: 0.86rem;
-  font-weight: 600;
-}
-
-.wallpaper-menu__toggle-state {
-  color: $color-muted;
-  font-size: 0.84rem;
-  min-width: 52px;
-}
-
-.wallpaper-menu__switch {
-}
-
-.wallpaper-menu__switch--focused {
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, #{$color-brand} 58%, #{$bg-surface} 42%);
-  border-radius: $radius-sm;
-}
-
-.wallpaper-menu__search {
-  border-radius: $radius-md;
-  border: 1px solid
-    color-mix(in srgb, #{$bg-surface-strong} 88%, transparent 12%);
-  background: color-mix(in srgb, #{$bg-surface-strong} 80%, #{$bg-surface} 20%);
-  color: $color-on-surface;
-  padding: 10px 12px;
-  min-height: 40px;
-  font-size: 0.98rem;
+  padding: 28px 10px 14px;
+  border-radius: 24px 24px 0 0;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  background: color-mix(in srgb, #{$bg-base} 72%, transparent 28%);
+  box-shadow:
+    0 -1px 0 rgba(255, 255, 255, 0.02),
+    0 10px 24px rgba(0, 0, 0, 0.14);
+  transition:
+    background 180ms ease-out,
+    border-color 180ms ease-out,
+    box-shadow 220ms ease-out;
 }
 
 .wallpaper-menu__grid {
-  padding: 2px;
+  padding: 10px 6px 12px;
 }
 
 .wallpaper-menu__scroller {
-  min-width: 740px;
+  min-height: 280px;
 }
 
 .wallpaper-menu__item {
   @include control-reset;
-  border-radius: $radius-md;
+  border-radius: 16px;
   border: 1px solid transparent;
-  padding: 9px;
+  padding: 6px 10px 4px;
   background: transparent;
-  min-width: 260px;
+  min-width: 280px;
+  transition:
+    background 180ms ease-out,
+    border-color 180ms ease-out,
+    transform 180ms ease-out,
+    box-shadow 180ms ease-out;
 
   &:hover {
-    border-color: color-mix(
-      in srgb,
-      #{$color-brand} 46%,
-      #{$bg-surface-strong} 54%
-    );
-    background: color-mix(in srgb, #{$accent-hover} 70%, #{$color-brand} 30%);
+    border-color: color-mix(in srgb, #{$color-brand} 34%, transparent 66%);
+    background: color-mix(in srgb, #{$bg-surface} 24%, transparent 76%);
+    transform: translateY(-2px);
   }
 }
 
 .wallpaper-menu__item--selected {
-  border-color: color-mix(
-    in srgb,
-    #{$color-brand} 46%,
-    #{$bg-surface-strong} 54%
-  );
-  background: color-mix(in srgb, #{$accent-hover} 70%, #{$color-brand} 30%);
+  position: relative;
+  z-index: 10;
+  border-color: color-mix(in srgb, #{$color-brand} 44%, transparent 56%);
+  background: color-mix(in srgb, #{$bg-surface} 18%, transparent 82%);
+  transform: translateY(-4px);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.12);
 }
 
 .wallpaper-menu__item-content {
   min-width: 0;
+  min-height: 218px;
+  align-items: center;
+}
+
+.wallpaper-menu__thumb-frame {
+  @include control-reset;
+  min-width: 260px;
+  min-height: 172px;
+  padding: 0;
 }
 
 .wallpaper-menu__thumb {
-  min-width: 240px;
-  min-height: 148px;
-  border-radius: $radius-md;
-  padding: 0;
-  border: 1px solid
-    color-mix(in srgb, #{$bg-surface-strong} 88%, transparent 12%);
-  background: color-mix(in srgb, #{$bg-surface-strong} 88%, #{$bg-surface} 12%);
+  width: 260px;
+  height: 172px;
+  border-radius: 14px;
+  border: 0;
+  background: transparent;
+  transform-origin: center center;
+  transition:
+    transform 220ms ease-out,
+    box-shadow 220ms ease-out;
 }
 
+.wallpaper-menu__item:hover .wallpaper-menu__thumb {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
+}
+
+.wallpaper-menu__thumb--selected {
+  transform: scale(1.25);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+}
 .wallpaper-menu__item-name {
   color: $color-on-surface;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: 0.75rem;
+  font-weight: 500;
+  min-width: 0;
+  min-height: 18px;
+  padding: 4px 6px 0;
 }

--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -21,7 +21,7 @@ window.WallpaperMenu {
 
 .wallpaper-menu__panel {
   margin-top: 0;
-  padding: 30px 10px 16px;
+  padding: 20px 10px 10px;
   border-radius: 24px 24px 0 0;
   border: 1px solid transparent;
   border-bottom: 0;
@@ -29,7 +29,8 @@ window.WallpaperMenu {
   box-shadow:
     0 -1px 0 rgba(255, 255, 255, 0.02),
     0 10px 24px rgba(0, 0, 0, 0.14);
-  transform: translateY(100%);
+  transform: translateY(120%);
+  transform-origin: center bottom;
   transition:
     transform 240ms ease-out,
     background 180ms ease-out,
@@ -42,11 +43,11 @@ window.WallpaperMenu {
 }
 
 .wallpaper-menu__grid {
-  padding: 6px 6px 14px;
+  padding: 4px 6px 8px;
 }
 
 .wallpaper-menu__scroller {
-  min-height: 400px;
+  min-height: 330px;
 }
 
 .wallpaper-menu__scroller viewport {

--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -20,7 +20,7 @@ window.WallpaperMenu {
 
 .wallpaper-menu__panel {
   margin-top: 0;
-  padding: 28px 10px 14px;
+  padding: 30px 10px 16px;
   border-radius: 24px 24px 0 0;
   border: 1px solid transparent;
   border-bottom: 0;
@@ -28,18 +28,24 @@ window.WallpaperMenu {
   box-shadow:
     0 -1px 0 rgba(255, 255, 255, 0.02),
     0 10px 24px rgba(0, 0, 0, 0.14);
+  transform: translateY(100%);
   transition:
+    transform 240ms ease-out,
     background 180ms ease-out,
     border-color 180ms ease-out,
     box-shadow 220ms ease-out;
 }
 
+.wallpaper-menu__panel--open {
+  transform: translateY(0);
+}
+
 .wallpaper-menu__grid {
-  padding: 10px 6px 12px;
+  padding: 6px 6px 14px;
 }
 
 .wallpaper-menu__scroller {
-  min-height: 280px;
+  min-height: 400px;
 }
 
 .wallpaper-menu__item {
@@ -49,6 +55,7 @@ window.WallpaperMenu {
   padding: 6px 10px 4px;
   background: transparent;
   min-width: 280px;
+  transform-origin: center bottom;
   transition:
     background 180ms ease-out,
     border-color 180ms ease-out,
@@ -64,11 +71,11 @@ window.WallpaperMenu {
 
 .wallpaper-menu__item--selected {
   position: relative;
-  z-index: 10;
-  border-color: color-mix(in srgb, #{$color-brand} 44%, transparent 56%);
-  background: color-mix(in srgb, #{$bg-surface} 18%, transparent 82%);
-  transform: translateY(-4px);
-  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.12);
+  z-index: 999;
+  border-color: color-mix(in srgb, #{$color-brand} 62%, transparent 38%);
+  background: color-mix(in srgb, #{$bg-surface} 26%, transparent 74%);
+  transform: translateY(-10px) scale(1.22);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.18);
 }
 
 .wallpaper-menu__item-content {
@@ -100,9 +107,8 @@ window.WallpaperMenu {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
 }
 
-.wallpaper-menu__thumb--selected {
-  transform: scale(1.25);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+.wallpaper-menu__item--selected .wallpaper-menu__thumb {
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.22);
 }
 .wallpaper-menu__item-name {
   color: $color-on-surface;

--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -16,6 +16,7 @@ window.WallpaperMenu {
   @include control-reset;
   min-width: 1px;
   min-height: 1px;
+  background: rgba(0, 0, 0, 0.35);
 }
 
 .wallpaper-menu__panel {
@@ -120,7 +121,9 @@ window.WallpaperMenu {
 }
 
 .wallpaper-menu__item--selected .wallpaper-menu__thumb {
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, #{$color-brand} 60%, transparent 40%),
+    0 18px 40px rgba(0, 0, 0, 0.28);
 }
 .wallpaper-menu__item-name {
   color: $color-on-surface;
@@ -129,4 +132,9 @@ window.WallpaperMenu {
   min-width: 0;
   min-height: 18px;
   padding: 4px 6px 0;
+}
+
+.wallpaper-menu__item--selected .wallpaper-menu__item-name {
+  color: color-mix(in srgb, #{$color-brand} 80%, #{$color-on-surface} 20%);
+  font-weight: 600;
 }

--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -107,6 +107,14 @@ window.WallpaperMenu {
     box-shadow 220ms ease-out;
 }
 
+.wallpaper-menu__thumb--adjacent {
+  transform: scale(0.92);
+}
+
+.wallpaper-menu__thumb--distant {
+  transform: scale(0.85);
+}
+
 .wallpaper-menu__item:hover .wallpaper-menu__thumb {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
 }

--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -48,6 +48,10 @@ window.WallpaperMenu {
   min-height: 400px;
 }
 
+.wallpaper-menu__scroller viewport {
+  overflow: visible;
+}
+
 .wallpaper-menu__item {
   @include control-reset;
   border-radius: 16px;

--- a/config/ags/style/features/_wallpaper-menu.scss
+++ b/config/ags/style/features/_wallpaper-menu.scss
@@ -71,7 +71,7 @@ window.WallpaperMenu {
 
 .wallpaper-menu__item--selected {
   position: relative;
-  z-index: 999;
+  z-index: 9999;
   border-color: color-mix(in srgb, #{$color-brand} 62%, transparent 38%);
   background: color-mix(in srgb, #{$bg-surface} 26%, transparent 74%);
   transform: translateY(-10px) scale(1.22);

--- a/config/ags/widget/wallpaper/WallpaperMenu.tsx
+++ b/config/ags/widget/wallpaper/WallpaperMenu.tsx
@@ -15,22 +15,19 @@ import {
 } from "../../services/wallpaper-menu"
 import { currentTheme, getThemeWindowClass } from "../../services/theme"
 
-const [queryState, setQueryState] = createState("")
 const [selectedIndexState, setSelectedIndexState] = createState(0)
-const [showAllWallpapersState, setShowAllWallpapersState] = createState(false)
-const [focusModeState, setFocusModeState] = createState<
-  "search" | "toggle" | "grid"
->("search")
 
-const wallpaperGridColumns = 3
-const wallpaperItemEstimatedHeight = 182
-const wallpaperGridRowSpacing = 8
-const wallpaperMenuPanelWidth = 760
-const wallpaperMenuScrollerWidth = 740
+const wallpaperItemEstimatedWidth = 288
+const wallpaperItemColumnSpacing = 8
+const wallpaperMenuScrollerHeight = 280
+const wallpaperDockTransitionDuration = 240
+const wallpaperScrollAnimationDuration = 160
+const wallpaperThumbWidth = 260
+const wallpaperThumbHeight = 172
 
 let wallpaperScroller: Gtk.ScrolledWindow | null = null
-let wallpaperSearchEntry: Gtk.Entry | null = null
-let wallpaperToggleSwitch: Gtk.Switch | null = null
+let wallpaperItemButtons: Gtk.Button[] = []
+let scrollAnimationSourceId: number | null = null
 
 const pointerCursor = Gdk.Cursor.new_from_name("pointer", null)
 
@@ -44,21 +41,10 @@ const isThemeWallpaper = (entry: WallpaperEntry, themeName: string) => {
   return topLevelDirectory === normalizedThemeName
 }
 
-const getFilteredWallpapers = (
-  query: string,
-  showAllWallpapers: boolean,
-  themeName: string,
-) => {
-  const normalized = normalize(query)
-  return getWallpaperEntries().filter((entry) => {
-    if (!showAllWallpapers && !isThemeWallpaper(entry, themeName)) return false
-    if (!normalized.length) return true
-    return normalize(`${entry.name} ${entry.relativePath}`).includes(normalized)
-  })
-}
-
 const getVisibleWallpapers = () =>
-  getFilteredWallpapers(queryState(), showAllWallpapersState(), currentTheme())
+  getWallpaperEntries().filter((entry) =>
+    isThemeWallpaper(entry, currentTheme()),
+  )
 
 const [visibleWallpapersState, setVisibleWallpapersState] = createState<
   WallpaperEntry[]
@@ -66,6 +52,17 @@ const [visibleWallpapersState, setVisibleWallpapersState] = createState<
 
 const refreshVisibleWallpapers = () => {
   setVisibleWallpapersState(getVisibleWallpapers())
+  wallpaperItemButtons = []
+}
+
+const reorderSelectedOnTop = () => {
+  const selectedBtn = wallpaperItemButtons[selectedIndexState()]
+  if (!selectedBtn) return
+
+  const parent = selectedBtn.get_parent()
+  if (!parent || !(parent instanceof Gtk.Box)) return
+
+  parent.reorder_child_after(selectedBtn, null)
 }
 
 const normalizeSelectedIndex = (nextIndex: number, resultCount: number) => {
@@ -85,60 +82,57 @@ const getDirectionalSelectedIndex = (
       return normalizeSelectedIndex(selectedIndex - 1, resultCount)
     case Gdk.KEY_Right:
       return normalizeSelectedIndex(selectedIndex + 1, resultCount)
-    case Gdk.KEY_Up:
-      return normalizeSelectedIndex(selectedIndex - wallpaperGridColumns, resultCount)
-    case Gdk.KEY_Down:
-      return normalizeSelectedIndex(selectedIndex + wallpaperGridColumns, resultCount)
     default:
       return selectedIndex
   }
 }
 
 const ensureSelectedWallpaperVisible = (selectedIndex: number) => {
-  const adjustment = wallpaperScroller?.vadjustment
+  const adjustment = wallpaperScroller?.hadjustment
   if (!adjustment) return
 
-  const rowHeight = wallpaperItemEstimatedHeight + wallpaperGridRowSpacing
-  const selectedRow = Math.floor(selectedIndex / wallpaperGridColumns)
-  const selectedTop = selectedRow * rowHeight
-  const selectedBottom = selectedTop + rowHeight
-  const viewportTop = adjustment.value
-  const viewportBottom = viewportTop + adjustment.page_size
+  const itemWidth = wallpaperItemEstimatedWidth + wallpaperItemColumnSpacing
+  const selectedStart = selectedIndex * itemWidth
+  const selectedEnd = selectedStart + itemWidth
+  const viewportStart = adjustment.value
+  const viewportEnd = viewportStart + adjustment.page_size
 
-  if (selectedTop < viewportTop) {
-    adjustment.set_value(selectedTop)
-    return
+  let targetValue: number | null = null
+
+  if (selectedStart < viewportStart) {
+    targetValue = selectedStart
   }
 
-  if (selectedBottom > viewportBottom) {
-    adjustment.set_value(selectedBottom - adjustment.page_size)
-  }
-}
-
-const focusOrder: Array<"search" | "toggle" | "grid"> = [
-  "search",
-  "toggle",
-  "grid",
-]
-
-const setFocusMode = (nextMode: "search" | "toggle" | "grid") => {
-  setFocusModeState(nextMode)
-
-  if (nextMode === "search") {
-    wallpaperSearchEntry?.grab_focus()
-    return
+  if (selectedEnd > viewportEnd) {
+    targetValue = selectedEnd - adjustment.page_size
   }
 
-  if (nextMode === "toggle") {
-    wallpaperToggleSwitch?.grab_focus()
-  }
-}
+  if (targetValue === null) return
 
-const cycleFocusMode = (step: number) => {
-  const currentIndex = focusOrder.indexOf(focusModeState())
-  const nextIndex =
-    (currentIndex + step + focusOrder.length) % focusOrder.length
-  setFocusMode(focusOrder[nextIndex])
+  if (scrollAnimationSourceId !== null) {
+    GLib.Source.remove(scrollAnimationSourceId)
+    scrollAnimationSourceId = null
+  }
+
+  const startValue = adjustment.value
+  const animationStart = GLib.get_monotonic_time()
+  const durationMicroseconds = wallpaperScrollAnimationDuration * 1000
+
+  scrollAnimationSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 16, () => {
+    const elapsed = GLib.get_monotonic_time() - animationStart
+    const progress = Math.min(elapsed / durationMicroseconds, 1)
+    const easedProgress = 1 - (1 - progress) * (1 - progress)
+    const nextValue = startValue + (targetValue - startValue) * easedProgress
+
+    adjustment.set_value(nextValue)
+
+    if (progress >= 1) {
+      scrollAnimationSourceId = null
+      return GLib.SOURCE_REMOVE
+    }
+
+    return GLib.SOURCE_CONTINUE
+  })
 }
 
 const sleep = (milliseconds: number) =>
@@ -209,55 +203,25 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
       onNotifyVisible={(self) => {
         if (self.visible) {
           self.present()
-          setQueryState("")
           setSelectedIndexState(0)
-          setFocusMode("search")
           refreshVisibleWallpapers()
-          wallpaperScroller?.vadjustment?.set_value(0)
+          wallpaperScroller?.hadjustment?.set_value(0)
         }
       }}
       application={app}
     >
       <Gtk.EventControllerKey
         propagationPhase={Gtk.PropagationPhase.CAPTURE}
-        onKeyPressed={(_, keyval, _keycode, state) => {
+        onKeyPressed={(_, keyval) => {
           if (keyval === Gdk.KEY_Escape) {
             closeWallpaperMenu()
             return true
           }
 
-          if (keyval === Gdk.KEY_Tab) {
-            const isShiftTab =
-              (state & Gdk.ModifierType.SHIFT_MASK) === Gdk.ModifierType.SHIFT_MASK
-            cycleFocusMode(isShiftTab ? -1 : 1)
-            return true
-          }
-
-          if (focusModeState() === "toggle") {
-            if (
-              keyval === Gdk.KEY_Return ||
-              keyval === Gdk.KEY_KP_Enter ||
-              keyval === Gdk.KEY_space
-            ) {
-              const nextShowAll = !showAllWallpapersState()
-              wallpaperToggleSwitch?.set_active(nextShowAll)
-              setShowAllWallpapersState(nextShowAll)
-              setSelectedIndexState(0)
-              refreshVisibleWallpapers()
-              wallpaperScroller?.vadjustment?.set_value(0)
-              return true
-            }
-
-            return false
-          }
-
           const isGridArrowKey =
-            keyval === Gdk.KEY_Left ||
-            keyval === Gdk.KEY_Right ||
-            keyval === Gdk.KEY_Up ||
-            keyval === Gdk.KEY_Down
+            keyval === Gdk.KEY_Left || keyval === Gdk.KEY_Right
 
-          if (focusModeState() === "grid" && isGridArrowKey) {
+          if (isGridArrowKey) {
             const filtered = visibleWallpapersState()
             if (filtered.length < 1) return true
 
@@ -268,13 +232,14 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
             )
             setSelectedIndexState(nextIndex)
             ensureSelectedWallpaperVisible(nextIndex)
+            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+              reorderSelectedOnTop()
+              return GLib.SOURCE_REMOVE
+            })
             return true
           }
 
-          if (
-            focusModeState() === "grid" &&
-            (keyval === Gdk.KEY_Return || keyval === Gdk.KEY_KP_Enter)
-          ) {
+          if (keyval === Gdk.KEY_Return || keyval === Gdk.KEY_KP_Enter) {
             const filtered = visibleWallpapersState()
             const selected = filtered[selectedIndexState()]
             if (!selected) return true
@@ -296,163 +261,101 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
           />
         </box>
 
-        <box
-          class="wallpaper-menu__panel"
-          orientation={Gtk.Orientation.VERTICAL}
-          spacing={8}
-          widthRequest={wallpaperMenuPanelWidth}
-          halign={Gtk.Align.CENTER}
-          valign={Gtk.Align.CENTER}
+        <Gtk.Revealer
+          revealChild={isWallpaperMenuVisible}
+          transitionType={Gtk.RevealerTransitionType.SLIDE_UP}
+          transitionDuration={wallpaperDockTransitionDuration}
+          hexpand
+          halign={Gtk.Align.FILL}
+          valign={Gtk.Align.END}
         >
-          <box class="wallpaper-menu__header" spacing={8}>
-            <label
-              class="wallpaper-menu__title"
-              label="Wallpapers"
-              xalign={0}
-              hexpand
-            />
-            <label
-              class="wallpaper-menu__count"
-              label={queryState(() => {
-                const filteredCount = visibleWallpapersState().length
-                const modeLabel = showAllWallpapersState()
-                  ? "all"
-                  : `${currentTheme() || "theme"}`
-
-                return `${filteredCount} files (${modeLabel})`
-              })}
-              xalign={1}
-            />
-            <label class="wallpaper-menu__toggle-label" label="Theme only" xalign={0} />
-            <switch
-              class={focusModeState((focusMode) =>
-                focusMode === "toggle"
-                  ? "wallpaper-menu__switch wallpaper-menu__switch--focused"
-                  : "wallpaper-menu__switch",
-              )}
-              cursor={pointerCursor}
-              valign={Gtk.Align.CENTER}
-              active={showAllWallpapersState((showAll) => !showAll)}
-              onMap={(self) => {
-                wallpaperToggleSwitch = self
-              }}
-              onNotifyActive={(self) => {
-                setFocusModeState("toggle")
-                setShowAllWallpapersState(!self.active)
-                setSelectedIndexState(0)
-                refreshVisibleWallpapers()
-                wallpaperScroller?.vadjustment?.set_value(0)
-              }}
-            />
-            <label
-              class="wallpaper-menu__toggle-state"
-              label={showAllWallpapersState((showAll) =>
-                showAll ? "all" : "theme",
-              )}
-              xalign={0}
-            />
-          </box>
-
-          <entry
-            class="wallpaper-menu__search"
-            placeholderText="Search wallpapers by name or path..."
-            text={queryState}
-            onMap={(self) => {
-              wallpaperSearchEntry = self
-            }}
-            onActivate={() => {
-              setFocusMode("grid")
-            }}
-            onNotifyHasFocus={(self) => {
-              if (self.hasFocus) setFocusModeState("search")
-            }}
-            onNotifyText={(self) => {
-              setQueryState(`${self.text ?? ""}`)
-              setSelectedIndexState(0)
-              refreshVisibleWallpapers()
-              wallpaperScroller?.vadjustment?.set_value(0)
-            }}
-            activatesDefault
-          />
-
-          <Gtk.ScrolledWindow
-            onMap={(self) => {
-              wallpaperScroller = self
-            }}
-            cssClasses={["wallpaper-menu__scroller"]}
-            minContentWidth={wallpaperMenuScrollerWidth}
-            propagateNaturalWidth={false}
-            vscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
-            hscrollbarPolicy={Gtk.PolicyType.NEVER}
-            widthRequest={wallpaperMenuScrollerWidth}
-            heightRequest={520}
+          <box
+            class="wallpaper-menu__panel"
+            orientation={Gtk.Orientation.VERTICAL}
+            spacing={0}
+            hexpand
+            marginStart={16}
+            marginEnd={16}
           >
-            <Gtk.FlowBox
-              cssClasses={["wallpaper-menu__grid"]}
-              columnSpacing={8}
-              rowSpacing={8}
-              minChildrenPerLine={3}
-              maxChildrenPerLine={3}
-              selectionMode={Gtk.SelectionMode.NONE}
+            <Gtk.ScrolledWindow
+              onMap={(self) => {
+                wallpaperScroller = self
+              }}
+              cssClasses={["wallpaper-menu__scroller"]}
+              minContentHeight={wallpaperMenuScrollerHeight}
+              propagateNaturalHeight={false}
+              vscrollbarPolicy={Gtk.PolicyType.NEVER}
+              hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
+              heightRequest={wallpaperMenuScrollerHeight}
             >
-              <For
-                each={visibleWallpapersState}
+              <box
+                class="wallpaper-menu__grid"
+                orientation={Gtk.Orientation.HORIZONTAL}
+                spacing={8}
               >
-                {(entry, index) => (
-                  <button
-                    canFocus={false}
-                    class={selectedIndexState((selectedIndex) =>
-                      selectedIndex === index.get()
-                        ? "wallpaper-menu__item wallpaper-menu__item--selected"
-                        : "wallpaper-menu__item",
-                    )}
-                    cursor={pointerCursor}
-                    tooltipText={entry.path}
-                    onClicked={() => {
-                      setFocusMode("grid")
-                      setSelectedIndexState(index.get())
-                      applyWallpaper(entry).catch(() => {})
-                    }}
-                  >
-                    <box
-                      class="wallpaper-menu__item-content"
-                      orientation={Gtk.Orientation.VERTICAL}
-                      spacing={6}
+                <For each={visibleWallpapersState}>
+                  {(entry, index) => (
+                    <button
+                      canFocus={false}
+                      class={selectedIndexState((selectedIndex) =>
+                        selectedIndex === index.get()
+                          ? "wallpaper-menu__item wallpaper-menu__item--selected"
+                          : "wallpaper-menu__item",
+                      )}
+                      cursor={pointerCursor}
+                      tooltipText={entry.path}
+                      onMap={(self) => {
+                        wallpaperItemButtons[index.get()] = self
+                      }}
+                      onClicked={() => {
+                        setSelectedIndexState(index.get())
+                        ensureSelectedWallpaperVisible(index.get())
+                        GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+                          reorderSelectedOnTop()
+                          return GLib.SOURCE_REMOVE
+                        })
+                        applyWallpaper(entry).catch(() => {})
+                      }}
                     >
-                      <Gtk.Picture
-                        class="wallpaper-menu__thumb"
-                        file={Gio.File.new_for_path(entry.path)}
-                        contentFit={Gtk.ContentFit.COVER}
-                        canShrink
-                        widthRequest={240}
-                        heightRequest={148}
-                        hexpand
-                      />
-                      <label
-                        class="wallpaper-menu__item-name"
-                        label={entry.name}
-                        xalign={0}
-                        justify={Gtk.Justification.LEFT}
-                        ellipsize={Pango.EllipsizeMode.END}
-                        singleLineMode
-                        maxWidthChars={20}
-                      />
-                    </box>
-                  </button>
-                )}
-              </For>
-            </Gtk.FlowBox>
-          </Gtk.ScrolledWindow>
-
-          <box class="wallpaper-menu__meta" spacing={8}>
-            <label
-              class="wallpaper-menu__hint"
-              label="Tab: search/toggle/grid  •  Arrows: move  •  Enter: apply  •  Esc: close"
-              xalign={0}
-              hexpand
-            />
+                      <box
+                        class="wallpaper-menu__item-content"
+                        orientation={Gtk.Orientation.VERTICAL}
+                        spacing={4}
+                      >
+                        <box class="wallpaper-menu__thumb-frame">
+                          <Gtk.Picture
+                            class={selectedIndexState((selectedIndex) =>
+                              selectedIndex === index.get()
+                                ? "wallpaper-menu__thumb wallpaper-menu__thumb--selected"
+                                : "wallpaper-menu__thumb",
+                            )}
+                            file={Gio.File.new_for_path(entry.path)}
+                            contentFit={Gtk.ContentFit.COVER}
+                            canShrink
+                            widthRequest={wallpaperThumbWidth}
+                            heightRequest={wallpaperThumbHeight}
+                            halign={Gtk.Align.CENTER}
+                            valign={Gtk.Align.CENTER}
+                          />
+                        </box>
+                        <label
+                          class="wallpaper-menu__item-name"
+                          label={entry.name}
+                          xalign={0}
+                          justify={Gtk.Justification.LEFT}
+                          ellipsize={Pango.EllipsizeMode.END}
+                          singleLineMode
+                          maxWidthChars={16}
+                          hexpand
+                        />
+                      </box>
+                    </button>
+                  )}
+                </For>
+              </box>
+            </Gtk.ScrolledWindow>
           </box>
-        </box>
+        </Gtk.Revealer>
       </overlay>
     </window>
   )

--- a/config/ags/widget/wallpaper/WallpaperMenu.tsx
+++ b/config/ags/widget/wallpaper/WallpaperMenu.tsx
@@ -323,6 +323,16 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
             hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
             heightRequest={wallpaperMenuScrollerHeight}
           >
+            <Gtk.EventControllerScroll
+              propagationPhase={Gtk.PropagationPhase.CAPTURE}
+              flags={Gtk.EventControllerScrollFlags.VERTICAL}
+              onScroll={(_, dx, dy) => {
+                const adj = wallpaperScroller?.hadjustment
+                if (!adj) return false
+                adj.set_value(adj.value + (dx || dy) * 4)
+                return true
+              }}
+            />
             <box
               class="wallpaper-menu__grid"
               orientation={Gtk.Orientation.HORIZONTAL}

--- a/config/ags/widget/wallpaper/WallpaperMenu.tsx
+++ b/config/ags/widget/wallpaper/WallpaperMenu.tsx
@@ -19,7 +19,7 @@ const [selectedIndexState, setSelectedIndexState] = createState(0)
 
 const wallpaperItemEstimatedWidth = 288
 const wallpaperItemColumnSpacing = 8
-const wallpaperMenuScrollerHeight = 280
+const wallpaperMenuScrollerHeight = 400
 const wallpaperDockTransitionDuration = 240
 const wallpaperScrollAnimationDuration = 160
 const wallpaperThumbWidth = 260
@@ -28,6 +28,38 @@ const wallpaperThumbHeight = 172
 let wallpaperScroller: Gtk.ScrolledWindow | null = null
 let wallpaperItemButtons: Gtk.Button[] = []
 let scrollAnimationSourceId: number | null = null
+const [panelState, setPanelState] = createState<"hidden" | "open">("hidden")
+let closeTimerId: number | null = null
+let openTimerId: number | null = null
+
+const cancelCloseTimer = () => {
+  if (closeTimerId !== null) {
+    GLib.Source.remove(closeTimerId)
+    closeTimerId = null
+  }
+}
+
+const cancelOpenTimer = () => {
+  if (openTimerId !== null) {
+    GLib.Source.remove(openTimerId)
+    openTimerId = null
+  }
+}
+
+const requestClosePanel = () => {
+  cancelOpenTimer()
+  setPanelState("hidden")
+  cancelCloseTimer()
+  closeTimerId = GLib.timeout_add(
+    GLib.PRIORITY_DEFAULT,
+    wallpaperDockTransitionDuration,
+    () => {
+      closeWallpaperMenu()
+      closeTimerId = null
+      return GLib.SOURCE_REMOVE
+    },
+  )
+}
 
 const pointerCursor = Gdk.Cursor.new_from_name("pointer", null)
 
@@ -196,7 +228,7 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
       class={getThemeWindowClass("WallpaperMenu")}
       visible={isWallpaperMenuVisible}
       gdkmonitor={gdkmonitor}
-      layer={Astal.Layer.TOP}
+      layer={Astal.Layer.OVERLAY}
       anchor={TOP | LEFT | RIGHT | BOTTOM}
       exclusivity={Astal.Exclusivity.IGNORE}
       keymode={Astal.Keymode.ON_DEMAND}
@@ -206,6 +238,14 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
           setSelectedIndexState(0)
           refreshVisibleWallpapers()
           wallpaperScroller?.hadjustment?.set_value(0)
+          cancelCloseTimer()
+          cancelOpenTimer()
+          setPanelState("hidden")
+          openTimerId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            setPanelState("open")
+            openTimerId = null
+            return GLib.SOURCE_REMOVE
+          })
         }
       }}
       application={app}
@@ -214,7 +254,7 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
         propagationPhase={Gtk.PropagationPhase.CAPTURE}
         onKeyPressed={(_, keyval) => {
           if (keyval === Gdk.KEY_Escape) {
-            closeWallpaperMenu()
+            requestClosePanel()
             return true
           }
 
@@ -232,10 +272,7 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
             )
             setSelectedIndexState(nextIndex)
             ensureSelectedWallpaperVisible(nextIndex)
-            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-              reorderSelectedOnTop()
-              return GLib.SOURCE_REMOVE
-            })
+            reorderSelectedOnTop()
             return true
           }
 
@@ -256,106 +293,97 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
           <Gtk.GestureClick
             button={0}
             onPressed={() => {
-              closeWallpaperMenu()
+              requestClosePanel()
             }}
           />
         </box>
 
-        <Gtk.Revealer
-          revealChild={isWallpaperMenuVisible}
-          transitionType={Gtk.RevealerTransitionType.SLIDE_UP}
-          transitionDuration={wallpaperDockTransitionDuration}
+        <box
+          class={panelState((state) =>
+            state === "open"
+              ? "wallpaper-menu__panel wallpaper-menu__panel--open"
+              : "wallpaper-menu__panel",
+          )}
+          orientation={Gtk.Orientation.VERTICAL}
+          spacing={0}
           hexpand
           halign={Gtk.Align.FILL}
           valign={Gtk.Align.END}
+          marginStart={16}
+          marginEnd={16}
         >
-          <box
-            class="wallpaper-menu__panel"
-            orientation={Gtk.Orientation.VERTICAL}
-            spacing={0}
-            hexpand
-            marginStart={16}
-            marginEnd={16}
+          <Gtk.ScrolledWindow
+            onMap={(self) => {
+              wallpaperScroller = self
+            }}
+            cssClasses={["wallpaper-menu__scroller"]}
+            minContentHeight={wallpaperMenuScrollerHeight}
+            propagateNaturalHeight={false}
+            vscrollbarPolicy={Gtk.PolicyType.NEVER}
+            hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
+            heightRequest={wallpaperMenuScrollerHeight}
           >
-            <Gtk.ScrolledWindow
-              onMap={(self) => {
-                wallpaperScroller = self
-              }}
-              cssClasses={["wallpaper-menu__scroller"]}
-              minContentHeight={wallpaperMenuScrollerHeight}
-              propagateNaturalHeight={false}
-              vscrollbarPolicy={Gtk.PolicyType.NEVER}
-              hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
-              heightRequest={wallpaperMenuScrollerHeight}
+            <box
+              class="wallpaper-menu__grid"
+              orientation={Gtk.Orientation.HORIZONTAL}
+              spacing={8}
+              valign={Gtk.Align.END}
             >
-              <box
-                class="wallpaper-menu__grid"
-                orientation={Gtk.Orientation.HORIZONTAL}
-                spacing={8}
-              >
-                <For each={visibleWallpapersState}>
-                  {(entry, index) => (
-                    <button
-                      canFocus={false}
-                      class={selectedIndexState((selectedIndex) =>
-                        selectedIndex === index.get()
-                          ? "wallpaper-menu__item wallpaper-menu__item--selected"
-                          : "wallpaper-menu__item",
-                      )}
-                      cursor={pointerCursor}
-                      tooltipText={entry.path}
-                      onMap={(self) => {
-                        wallpaperItemButtons[index.get()] = self
-                      }}
-                      onClicked={() => {
-                        setSelectedIndexState(index.get())
-                        ensureSelectedWallpaperVisible(index.get())
-                        GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-                          reorderSelectedOnTop()
-                          return GLib.SOURCE_REMOVE
-                        })
-                        applyWallpaper(entry).catch(() => {})
-                      }}
+              <For each={visibleWallpapersState}>
+                {(entry, index) => (
+                  <button
+                    canFocus={false}
+                    class={selectedIndexState((selectedIndex) =>
+                      selectedIndex === index.get()
+                        ? "wallpaper-menu__item wallpaper-menu__item--selected"
+                        : "wallpaper-menu__item",
+                    )}
+                    cursor={pointerCursor}
+                    tooltipText={entry.path}
+                    onMap={(self) => {
+                      wallpaperItemButtons[index.get()] = self
+                    }}
+                    onClicked={() => {
+                      setSelectedIndexState(index.get())
+                      ensureSelectedWallpaperVisible(index.get())
+                      reorderSelectedOnTop()
+                      applyWallpaper(entry).catch(() => {})
+                    }}
+                  >
+                    <box
+                      class="wallpaper-menu__item-content"
+                      orientation={Gtk.Orientation.VERTICAL}
+                      spacing={4}
                     >
-                      <box
-                        class="wallpaper-menu__item-content"
-                        orientation={Gtk.Orientation.VERTICAL}
-                        spacing={4}
-                      >
-                        <box class="wallpaper-menu__thumb-frame">
-                          <Gtk.Picture
-                            class={selectedIndexState((selectedIndex) =>
-                              selectedIndex === index.get()
-                                ? "wallpaper-menu__thumb wallpaper-menu__thumb--selected"
-                                : "wallpaper-menu__thumb",
-                            )}
-                            file={Gio.File.new_for_path(entry.path)}
-                            contentFit={Gtk.ContentFit.COVER}
-                            canShrink
-                            widthRequest={wallpaperThumbWidth}
-                            heightRequest={wallpaperThumbHeight}
-                            halign={Gtk.Align.CENTER}
-                            valign={Gtk.Align.CENTER}
-                          />
-                        </box>
-                        <label
-                          class="wallpaper-menu__item-name"
-                          label={entry.name}
-                          xalign={0}
-                          justify={Gtk.Justification.LEFT}
-                          ellipsize={Pango.EllipsizeMode.END}
-                          singleLineMode
-                          maxWidthChars={16}
-                          hexpand
+                      <box class="wallpaper-menu__thumb-frame">
+                        <Gtk.Picture
+                          class="wallpaper-menu__thumb"
+                          file={Gio.File.new_for_path(entry.path)}
+                          contentFit={Gtk.ContentFit.COVER}
+                          canShrink
+                          widthRequest={wallpaperThumbWidth}
+                          heightRequest={wallpaperThumbHeight}
+                          halign={Gtk.Align.CENTER}
+                          valign={Gtk.Align.CENTER}
                         />
                       </box>
-                    </button>
-                  )}
-                </For>
-              </box>
-            </Gtk.ScrolledWindow>
-          </box>
-        </Gtk.Revealer>
+                      <label
+                        class="wallpaper-menu__item-name"
+                        label={entry.name}
+                        xalign={0}
+                        justify={Gtk.Justification.LEFT}
+                        ellipsize={Pango.EllipsizeMode.END}
+                        singleLineMode
+                        maxWidthChars={16}
+                        hexpand
+                      />
+                    </box>
+                  </button>
+                )}
+              </For>
+            </box>
+          </Gtk.ScrolledWindow>
+        </box>
       </overlay>
     </window>
   )

--- a/config/ags/widget/wallpaper/WallpaperMenu.tsx
+++ b/config/ags/widget/wallpaper/WallpaperMenu.tsx
@@ -19,7 +19,7 @@ const [selectedIndexState, setSelectedIndexState] = createState(0)
 
 const wallpaperItemEstimatedWidth = 288
 const wallpaperItemColumnSpacing = 8
-const wallpaperMenuScrollerHeight = 400
+const wallpaperMenuScrollerHeight = 330
 const wallpaperDockTransitionDuration = 240
 const wallpaperScrollAnimationDuration = 160
 const wallpaperThumbWidth = 260
@@ -309,8 +309,6 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
           hexpand
           halign={Gtk.Align.FILL}
           valign={Gtk.Align.END}
-          marginStart={16}
-          marginEnd={16}
         >
           <Gtk.ScrolledWindow
             onMap={(self) => {

--- a/config/ags/widget/wallpaper/WallpaperMenu.tsx
+++ b/config/ags/widget/wallpaper/WallpaperMenu.tsx
@@ -357,7 +357,15 @@ export default function WallpaperMenu(gdkmonitor: Gdk.Monitor) {
                     >
                       <box class="wallpaper-menu__thumb-frame">
                         <Gtk.Picture
-                          class="wallpaper-menu__thumb"
+                          class={selectedIndexState((selectedIndex) => {
+                            const base = "wallpaper-menu__thumb"
+                            const idx = index.get()
+                            if (idx === selectedIndex) return base
+                            const distance = Math.abs(idx - selectedIndex)
+                            if (distance === 1)
+                              return `${base} wallpaper-menu__thumb--adjacent`
+                            return `${base} wallpaper-menu__thumb--distant`
+                          })}
                           file={Gio.File.new_for_path(entry.path)}
                           contentFit={Gtk.ContentFit.COVER}
                           canShrink


### PR DESCRIPTION
## Summary
- redesign the wallpaper menu into a bottom dock layout
- add slide-up open animation, focused-item prominence, and thumb distance scaling
- reduce dock height and use full-width bottom alignment

## Testing
- not run (UI change)
